### PR TITLE
Reconstruct two magick commands to one

### DIFF
--- a/src/operations/fill/index.ts
+++ b/src/operations/fill/index.ts
@@ -1,11 +1,11 @@
 import ImageDefinition, { DefinitionRequirement } from '../../imagedef';
+import { Gravity } from '../Gravity';
 import { magickGravityMap } from '../magickGravityMap';
 import Operation from './../operation';
 import { FillConfig } from './types';
-import { Gravity } from '../Gravity';
 
 export const magickOptions = (config: FillConfig, state: ImageDefinition): string[] => {
-  const gravity = <Gravity> config.gravity;
+  const gravity = config.gravity as Gravity;
   return [
     '-',
     `-resize ${config.width}x${config.height}^`,
@@ -18,8 +18,8 @@ export const magickOptions = (config: FillConfig, state: ImageDefinition): strin
 export const transformState = (config: FillConfig, state: ImageDefinition): ImageDefinition => {
   return {
     ...state,
-    width: <number> config.width,
-    height: <number> config.height,
+    width: config.width as number,
+    height: config.height as number,
   };
 };
 

--- a/src/transform/__tests__/join-commands.ts
+++ b/src/transform/__tests__/join-commands.ts
@@ -1,0 +1,116 @@
+import joinCommands from '../join-commands';
+
+const exampleCommands = {
+  crop: 'magick - -gravity Center -crop 720x1000+0+0 -repage 720x1000+0+0 jpeg:-',
+  format: 'convert - jpeg:-',
+  fit: 'magick - -resize 1000x1000 jpeg:-',
+  fill: 'magick -resize 1000x1000^ -gravity Center -extent 1000x1000 jpeg:-',
+  magickCompress: 'magick - -quality=92 jpeg:-',
+  strip: 'exiftool -all= -',
+};
+
+describe('.joinCommands', () => {
+  describe('Joining two incompatible commands', () => {
+    it('should pipe first command to second command', () => {
+      const commands = ['format', 'strip'].map((cmd) => exampleCommands[cmd]);
+      const joined = joinCommands(commands);
+      expect(joined).toBe('convert - jpeg:- | exiftool -all= -');
+    });
+  });
+  describe('Joining two magick commands', () => {
+    const fixtures = {
+      'crop + format': {
+        cmds: ['crop', 'format'],
+        expected: 'magick - -gravity Center -crop 720x1000+0+0 -repage 720x1000+0+0 jpeg:-',
+      },
+      'fit + format': {
+        cmds: ['fit', 'format'],
+        expected: 'magick - -resize 1000x1000 jpeg:-',
+      },
+      'fill + format': {
+        cmds: ['fill', 'format'],
+        expected: 'magick -resize 1000x1000^ -gravity Center -extent 1000x1000 jpeg:-',
+      },
+      'compress + format': {
+        cmds: ['magickCompress', 'format'],
+        expected: 'magick - -quality=92 jpeg:-',
+      },
+
+      'crop + compress': {
+        cmds: ['crop', 'magickCompress'],
+        expected: 'magick - -gravity Center -crop 720x1000+0+0 -repage 720x1000+0+0 -quality=92 jpeg:-',
+      },
+      'fit + compress': {
+        cmds: ['fit', 'magickCompress'],
+        expected: 'magick - -resize 1000x1000 -quality=92 jpeg:-',
+      },
+      'fill + compress': {
+        cmds: ['fill', 'magickCompress'],
+        expected: 'magick -resize 1000x1000^ -gravity Center -extent 1000x1000 -quality=92 jpeg:-',
+      },
+      'format + compress': {
+        cmds: ['format', 'magickCompress'],
+        expected: 'magick - -quality=92 jpeg:-',
+      },
+    };
+
+    for (const fixtureName of Object.keys(fixtures)) {
+      const fixture = fixtures[fixtureName];
+      it(`should join ${fixtureName}`, () => {
+        const commands = fixture.cmds.map((cmd) => exampleCommands[cmd]);
+        const joined = joinCommands(commands);
+        expect(joined).toBe(fixture.expected);
+      });
+    }
+  });
+
+  describe('Joining three magick commands', () => {
+    // .joinCommands only join two subsequent commands
+    // and thus will not join all three commands even if
+    // it is possible. Only the two first commands will be joined
+    const fixtures = {
+      'crop + format + compress': {
+        cmds: ['crop', 'format', 'magickCompress'],
+        expected: 'magick - -gravity Center -crop 720x1000+0+0 -repage 720x1000+0+0 jpeg:- | ' +
+         'magick - -quality=92 jpeg:-',
+      },
+    };
+
+    for (const fixtureName of Object.keys(fixtures)) {
+      const fixture = fixtures[fixtureName];
+      it(`should join ${fixtureName}`, () => {
+        const commands = fixture.cmds.map((cmd) => exampleCommands[cmd]);
+        const joined = joinCommands(commands);
+        expect(joined).toBe(fixture.expected);
+      });
+    }
+  });
+
+
+  describe('Joining three incompatible commands', () => {
+    const fixtures = {
+      'crop + strip + compress': {
+        cmds: ['crop', 'strip', 'magickCompress'],
+        expected: 'magick - -gravity Center -crop 720x1000+0+0 -repage 720x1000+0+0 jpeg:- | ' +
+         'exiftool -all= - | magick - -quality=92 jpeg:-',
+      },
+    };
+
+    for (const fixtureName of Object.keys(fixtures)) {
+      const fixture = fixtures[fixtureName];
+      it(`should join ${fixtureName}`, () => {
+        const commands = fixture.cmds.map((cmd) => exampleCommands[cmd]);
+        const joined = joinCommands(commands);
+        expect(joined).toBe(fixture.expected);
+      });
+    }
+  });
+
+  describe('Joining arbitrary commands', () => {
+    it('should not join arbitrary commands', () => {
+      const commands = ['aaa', 'bbb', 'ccc', 'ddd'];
+      const joined = joinCommands(commands);
+      expect(joined).toBe('aaa | bbb | ccc | ddd');
+    });
+  });
+});

--- a/src/transform/join-commands.ts
+++ b/src/transform/join-commands.ts
@@ -1,3 +1,83 @@
+/**
+ * Some two commands, especially magick commands, can be reconstructed
+ * as a single command to improve performance.
+ *
+ * This module reconstructs compatible commands
+ * and joins the rest with unix pipes.
+ */
+
+const joinableCommands = {
+  '[any magick] + [format]': {
+    // example:
+    // "magick - -resize 1000x1000 jpeg:- | convert - png:-" ->
+    // "magick - -resize 1000x1000 png:-"
+    commands: [
+      // Any magick command
+      // first group is settings and second group is output format
+      /^(magick .*) ([\w]+:-)$/,
+
+      // Format command
+      // first group is output format
+      /^convert - ([\w]+:-)$/,
+    ],
+    join: ([ first, second ]) => {
+      return `${first[1]} ${second[1]}`;
+    },
+  },
+
+  '[any magick] + [magickCompress]': {
+    // example:
+    // "magick - -resize 100x100 jpeg:- | magick -quality=92 jpeg:-" ->
+    // "magick - -resize 100x100 -quality=92 jpeg:-"
+    commands: [
+      // Any magick command
+      // first group is settings and second group is output format
+      /^(?:magick|convert) (.*) ([\w]+:-)$/,
+
+      // compress command
+      // first group is quality parameter
+      /^magick - (-quality=[0-9]+) [\w]+:-$/,
+    ],
+
+    join: ([ first, second ]) => {
+      return `magick ${first[1]} ${second[1]} ${first[2]}`;
+    },
+  },
+};
+
 export default (commands: string[]): string => {
-  return commands.join(' | ');
+  // Run a single pass over the commands, joining two commands where possible.
+  // Further optimizations could allow joining more than two commands into one,
+  // but such optimizations are not done here.
+  const joinedCommands = [];
+  commandLoop: for (let i = 0; i < commands.length; i += 1) {
+    if (i === commands.length - 1) {
+      joinedCommands.push(commands[i]);
+      continue;
+    }
+    const fst = commands[i];
+    const snd = commands[i + 1];
+
+    for (const matcherName of Object.keys(joinableCommands)) {
+      const matcher = joinableCommands[matcherName];
+
+      const fstMatch = fst.match(matcher.commands[0]);
+      if (fstMatch === null) { continue; }
+
+      const sndMatch = snd.match(matcher.commands[1]);
+      if (sndMatch === null) { continue; }
+
+      // These commands can be joined
+      joinedCommands.push(matcher.join([fstMatch, sndMatch]));
+      i++;
+      continue commandLoop;
+    }
+
+    // The commands could not be joined
+    // push them as is
+    joinedCommands.push(fst);
+  }
+
+  return joinedCommands.join(' | ');
+
 };


### PR DESCRIPTION
Reconstructs certain two magick commands into one to improve performance. The two commands that have been joined for now (as their the most common joinable commands) are:
- [any magick command] + [format]
- [any magick command] + [magick compress]

[master]
```
Running t_720 capitalism.png...
Running 5s test @ http://spacechop-benched:3000/t_720/capitalism.png
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   378.09ms   65.99ms 568.53ms   91.67%
    Req/Sec     2.25      0.75     3.00     83.33%
  12 requests in 5.08s, 329.45KB read
Requests/sec:      2.36
Transfer/sec:     64.89KB

Running t_thumb capitalism.png...
Running 5s test @ http://spacechop-benched:3000/t_thumb/capitalism.png
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   181.10ms   11.29ms 214.02ms   77.78%
    Req/Sec     5.56      2.39    10.00     74.07%
  27 requests in 5.03s, 103.10KB read
Requests/sec:      5.36
Transfer/sec:     20.48KB

Running t_720 rally.jpg...
Running 5s test @ http://spacechop-benched:3000/t_720/rally.jpg
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.08s    53.76ms   1.14s    50.00%
    Req/Sec     0.00      0.00     0.00    100.00%
  4 requests in 5.04s, 798.20KB read
Requests/sec:      0.79
Transfer/sec:    158.34KB

Running t_thumb rally.jpg...
Running 5s test @ http://spacechop-benched:3000/t_thumb/rally.jpg
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   979.12ms   29.88ms   1.02s    60.00%
    Req/Sec     0.20      0.45     1.00     80.00%
  5 requests in 5.04s, 211.29KB read
Requests/sec:      0.99
Transfer/sec:     41.91KB

Running t_720 wallet.jpg...
Running 5s test @ http://spacechop-benched:3000/t_720/wallet.jpg
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   388.41ms    8.41ms 409.01ms   75.00%
    Req/Sec     2.08      0.51     3.00     75.00%
  12 requests in 5.04s, 1.18MB read
Requests/sec:      2.38
Transfer/sec:    239.85KB

Running t_thumb wallet.jpg...
Running 5s test @ http://spacechop-benched:3000/t_thumb/wallet.jpg
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    73.81ms    7.33ms 107.31ms   88.24%
    Req/Sec    13.30      4.85    20.00     64.00%
  68 requests in 5.04s, 412.20KB read
Requests/sec:     13.50
Transfer/sec:     81.86KB
```
[join-commands]
```
Running t_720 capitalism.png...
Running 5s test @ http://spacechop-benched:3000/t_720/capitalism.png
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   278.99ms   21.80ms 346.88ms   88.89%
    Req/Sec     3.33      0.84     5.00     77.78%
  18 requests in 5.04s, 456.10KB read
Requests/sec:      3.57
Transfer/sec:     90.44KB

Running t_thumb capitalism.png...
Running 5s test @ http://spacechop-benched:3000/t_thumb/capitalism.png
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   197.00ms   33.79ms 284.66ms   80.00%
    Req/Sec     5.00      2.20    10.00     84.00%
  25 requests in 5.04s, 92.09KB read
Requests/sec:      4.96
Transfer/sec:     18.26KB

Running t_720 rally.jpg...
Running 5s test @ http://spacechop-benched:3000/t_720/rally.jpg
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.00s   116.20ms   1.21s    80.00%
    Req/Sec     0.40      0.55     1.00     60.00%
  5 requests in 5.05s, 0.97MB read
Requests/sec:      0.99
Transfer/sec:    197.65KB

Running t_thumb rally.jpg...
Running 5s test @ http://spacechop-benched:3000/t_thumb/rally.jpg
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   993.49ms   47.26ms   1.07s    80.00%
    Req/Sec     0.20      0.45     1.00     80.00%
  5 requests in 5.03s, 211.29KB read
Requests/sec:      0.99
Transfer/sec:     42.00KB

Running t_720 wallet.jpg...
Running 5s test @ http://spacechop-benched:3000/t_720/wallet.jpg
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   350.68ms   22.61ms 396.54ms   78.57%
    Req/Sec     2.50      0.52     3.00    100.00%
  14 requests in 5.04s, 1.38MB read
Requests/sec:      2.78
Transfer/sec:    279.83KB

Running t_thumb wallet.jpg...
Running 5s test @ http://spacechop-benched:3000/t_thumb/wallet.jpg
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    72.67ms    7.88ms 112.92ms   91.30%
    Req/Sec    13.63      5.05    20.00     61.22%
  69 requests in 5.05s, 418.29KB read
Requests/sec:     13.68
Transfer/sec:     82.91KB
```


More commands can be joined for example (fit + fill) but the benefit is too low as they're not AFAIK used together that often.