### PR TITLE
Add hash parameter when saving transformation to storage

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -49,7 +49,7 @@ A storage provider is the _S3 Storage_ which will upload the image to your S3 bu
 storage:
   s3:
     bucket_name: 'my-images'
-    path: 'transformed/:preset/:image'
+    path: 'transformed/:preset/:image.:hash'
 ```
 
 Again, we make use of parameters to describe where the transformation should be stored.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "duplex-child-process": "~1.0.0",
     "express": "~4.16.3",
     "js-yaml": "~3.12.0",
+    "object-hash": "~1.3.0",
     "path-to-regexp": "~2.4.0",
     "request": "~2.88.0",
     "runtypes": "~2.1.6"

--- a/src/config/__tests__/storage/__snapshots__/hash.ts.snap
+++ b/src/config/__tests__/storage/__snapshots__/hash.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validate hash should to throw error if hash parameter is not used in storage 1`] = `"storage.s3: Missing usage of parameter \\":hash\\""`;

--- a/src/config/__tests__/storage/hash.ts
+++ b/src/config/__tests__/storage/hash.ts
@@ -1,0 +1,55 @@
+import { Config } from '../../../types/Config';
+import { validate } from '../../validate';
+
+describe('validate hash', () => {
+  it('should to throw error if hash parameter is not used in storage', () => {
+    const config: Config = {
+      paths: ['/:preset/:image'],
+      sources: [{
+        s3: {
+          access_key_id: 'access_key_id',
+          secret_access_key: 'secret_access_key',
+          region: 'region',
+          bucket_name: 'bucket_name',
+          path: ':image',
+        },
+      }],
+      storage: {
+        s3: {
+          access_key_id: 'access_key_id',
+          secret_access_key: 'secret_access_key',
+          region: 'region',
+          bucket_name: 'bucket_name',
+          path: ':image',
+        },
+      },
+      presets: {},
+    };
+    expect(() => validate(config)).toThrowErrorMatchingSnapshot();
+  });
+  it('should not throw error if hash parameter is used in storage', () => {
+    const config: Config = {
+      paths: ['/:preset/:image'],
+      sources: [{
+        s3: {
+          access_key_id: 'access_key_id',
+          secret_access_key: 'secret_access_key',
+          region: 'region',
+          bucket_name: 'bucket_name',
+          path: ':image',
+        },
+      }],
+      storage: {
+        s3: {
+          access_key_id: 'access_key_id',
+          secret_access_key: 'secret_access_key',
+          region: 'region',
+          bucket_name: 'bucket_name',
+          path: ':image.:hash',
+        },
+      },
+      presets: {},
+    };
+    expect(() => validate(config)).not.toThrow();
+  });
+});

--- a/src/config/__tests__/storage/s3.ts
+++ b/src/config/__tests__/storage/s3.ts
@@ -27,7 +27,7 @@ describe('validate s3 storage', () => {
     expect(() => validate(config)).toThrowErrorMatchingSnapshot();
   });
 
-  it('should not throw on valid source', () => {
+  it('should not throw on valid storage', () => {
     const config = {
       paths: ['/:preset/:image'],
       sources: [{
@@ -40,6 +40,15 @@ describe('validate s3 storage', () => {
         },
       }],
       presets: {},
+      storage: {
+        s3: {
+          access_key_id: 'access_key_id',
+          secret_access_key: 'secret_access_key',
+          region: 'region',
+          bucket_name: 'bucket_name',
+          path: ':image.:hash',
+        },
+      },
     };
     expect(() => validate(config)).not.toThrow();
   });

--- a/src/config/params.ts
+++ b/src/config/params.ts
@@ -1,4 +1,5 @@
 export interface Params {
   preset: string;
+  hash?: string;
   [key: string]: any;
 }

--- a/src/lib/validateParams.ts
+++ b/src/lib/validateParams.ts
@@ -2,7 +2,7 @@ import extract from './extractPathParams';
 
 export default (config) => {
   const errors = [];
-  const { paths, sources, presets } = config;
+  const { paths, sources, presets, storage} = config;
   // Extract path params.
   const params = {};
   for (const path of paths) {
@@ -21,7 +21,7 @@ export default (config) => {
     for (const key of Object.keys(source[name])) {
       if (source[name][key].length > 0) {
         const sourceParams = extract(source[name][key]);
-        for (const param of  sourceParams) {
+        for (const param of sourceParams) {
           if (typeof params[param.name] !== 'number') {
             errors.push(`source[${i}].${name}.${key}: Missing param "${param.name}" in paths`);
           } else {
@@ -48,6 +48,28 @@ export default (config) => {
           }
         }
       }
+    }
+  }
+
+  // If storage is defined it should make use of the `:hash` parameter
+  // in the configuration. It could be in any of the keys, but it must
+  // be in at least one.
+  if (storage) {
+    const name = Object.keys(storage)[0];
+    const strg = storage[name];
+    let seenHashUsage = false;
+    for (const key of Object.keys(strg)) {
+      if (strg[key].length > 0) {
+        const storageParams = extract(strg[key]);
+        for (const param of storageParams) {
+          if (param.name === 'hash') {
+            seenHashUsage = true;
+          }
+        }
+      }
+    }
+    if (!seenHashUsage) {
+      errors.push(`storage.${name}: Missing usage of parameter ":hash"`);
     }
   }
 

--- a/src/spacechop.ts
+++ b/src/spacechop.ts
@@ -8,6 +8,7 @@ import StreamSwitch from './lib/stream-switch';
 import instantiateSource from './sources/lib/instantiate-source';
 import lookThroughSources from './sources/lib/look-through-sources';
 import Source from './sources/source';
+import hash from './storage/hash';
 import fetchFromStorage from './storage/lib/fetch-from-storage';
 import instantiateStorage from './storage/lib/instantiate-storage';
 import uploadToStorage from './storage/lib/upload-to-storage';
@@ -41,6 +42,9 @@ export const requestHandler = (
 
   // populate steps with params.
   const steps = populatePresetParams(preset.steps, params);
+  if (storage) {
+    params.hash = hash(steps);
+  }
 
   // check if transformation is already done and exists in storage
   if (storage) {

--- a/src/storage/__tests__/hash.ts
+++ b/src/storage/__tests__/hash.ts
@@ -1,0 +1,124 @@
+import { Step } from '../../types/Step';
+import hash from './../hash';
+
+describe('.hash', () => {
+  it('should return same hash for same steps', () => {
+    const steps1: Step[] = [{
+      $crop: {
+        width: 100,
+        height: 100,
+      },
+    }];
+    const steps2: Step[] = [{
+      $crop: {
+        width: 100,
+        height: 100,
+      },
+    }];
+
+    const hash1 = hash(steps1);
+    const hash2 = hash(steps2);
+    expect(hash1).toBe(hash2);
+  });
+
+  it('should return same hash for same steps with object keys in different order', () => {
+    const steps1: Step[] = [{
+      $crop: {
+        width: 100,
+        height: 100,
+      },
+    }];
+    const steps2: Step[] = [{
+      $crop: {
+        height: 100,
+        width: 100,
+      },
+    }];
+
+    const hash1 = hash(steps1);
+    const hash2 = hash(steps2);
+    expect(hash1).toBe(hash2);
+  });
+
+  it('should not return same hash if a new property is added', () => {
+    const steps1: Step[] = [{
+      $crop: {
+        width: 100,
+        height: 100,
+        gravity: 'center',
+      },
+    }];
+    const steps2: Step[] = [{
+      $crop: {
+        width: 100,
+        height: 100,
+      },
+    }];
+
+    const hash1 = hash(steps1);
+    const hash2 = hash(steps2);
+    expect(hash1).not.toBe(hash2);
+  });
+  it('should not return same hash if property changes value', () => {
+    const steps1: Step[] = [{
+      $crop: {
+        width: 100,
+        height: 100,
+      },
+    }];
+    const steps2: Step[] = [{
+      $crop: {
+        width: 100,
+        height: 150,
+      },
+    }];
+
+    const hash1 = hash(steps1);
+    const hash2 = hash(steps2);
+    expect(hash1).not.toBe(hash2);
+  });
+  it('should not return same hash if property changes value', () => {
+    const steps1: Step[] = [{
+      $crop: {
+        width: 100,
+        height: 100,
+      },
+    }];
+    const steps2: Step[] = [{
+      $crop: {
+        width: 100,
+        height: 150,
+      },
+    }];
+
+    const hash1 = hash(steps1);
+    const hash2 = hash(steps2);
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('should not return same hash if operations changes order', () => {
+    const steps1: Step[] = [
+      { $crop: {
+        width: 100,
+        height: 100,
+      } },
+      { $strip: {
+
+      }},
+    ];
+    const steps2: Step[] = [
+      { $strip: {
+
+      }},
+      { $crop: {
+        width: 100,
+        height: 100,
+      } },
+    ];
+
+
+    const hash1 = hash(steps1);
+    const hash2 = hash(steps2);
+    expect(hash1).not.toBe(hash2);
+  });
+});

--- a/src/storage/hash.ts
+++ b/src/storage/hash.ts
@@ -1,0 +1,6 @@
+import hash from 'object-hash';
+import { Step } from '../types/Step';
+
+export default (steps: Step[]): string => {
+  return hash(steps, {});
+};

--- a/src/test/__tests__/storage-set.ts
+++ b/src/test/__tests__/storage-set.ts
@@ -61,9 +61,10 @@ describe('Configured storage', () => {
       request.setParams(1, 'grid.png');
       await handler(request, response);
     });
-    it('should check storage', () => {
-      expect(storage.exists).toHaveBeenCalled();
-      expect(storage.stream).toHaveBeenCalled();
+
+    it('should check storage (with hash parameters)', () => {
+      expect(storage.exists).toHaveBeenCalledWith(expect.objectContaining({ hash: expect.any(String) }));
+      expect(storage.stream).toHaveBeenCalledWith(expect.objectContaining({ hash: expect.any(String) }));
     });
     it('should not check source', () => {
       expect(sources[0].exists).not.toHaveBeenCalled();
@@ -105,15 +106,20 @@ describe('Configured storage', () => {
       request.setParams(1, 'grid.png');
       await handler(request, response);
     });
-    it('should check storage', () => {
-      expect(storage.exists).toHaveBeenCalled();
+    it('should check storage (with hash parameter)', () => {
+      expect(storage.exists).toHaveBeenCalledWith(expect.objectContaining({ hash: expect.any(String) }));
     });
     it('should check source', () => {
       expect(sources[0].exists).toHaveBeenCalled();
       expect(sources[0].stream).toHaveBeenCalled();
     });
-    it('should call storage .upload', () => {
-      expect(storage.upload).toHaveBeenCalled();
+    it('should call storage .upload (with hash parameter)', () => {
+      expect(storage.upload).toHaveBeenCalledWith(
+        expect.objectContaining({ hash: expect.any(String) }),
+        // stream
+        expect.anything(),
+        // contentType
+        expect.anything());
     });
   });
 });


### PR DESCRIPTION
Hash is calculated with https://github.com/puleos/object-hash using sha1.
Only steps is hashed, so no other potentially secret parameters in the configuration.

If a storage is defined in configuration hash needs to be in the parameters (see tests).