### PR TITLE
Add configuration to disable chunked encoding

### DIFF
--- a/src/test/__tests__/respond.ts
+++ b/src/test/__tests__/respond.ts
@@ -1,0 +1,102 @@
+import path from 'path';
+import { PassThrough } from 'stream';
+import ImageDefinition from '../../imagedef';
+import { Config } from '../../types/Config';
+import { Mime } from '../../types/Format';
+import assetsFolder from '../assets/dirname';
+import { Response } from '../utils/expressMocks';
+import { respond } from './../../spacechop';
+
+const randomString = (length) => {
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+};
+
+const createStream = ({length = 100, slices = 10, interval = 5} = {}) => {
+  if (length % slices !== 0) {
+    throw new Error('Length must be divisible by slices');
+  }
+  const chunks = [];
+  for (let i = 0; i < slices; i++) {
+    chunks.push(randomString(length / slices));
+  }
+  const stream = new PassThrough();
+  let j = 0;
+  const timer = setInterval(() => {
+    stream.push(Buffer.from(chunks[j++]));
+    if (j === slices) {
+      clearInterval(timer);
+      stream.push(null);
+    }
+  }, interval);
+  return stream;
+ };
+
+
+describe('Respond', () => {
+  const p = '/:preset/:image';
+  const config: Config = {
+    sources: [{
+      volume: {
+        root: path.join(assetsFolder, ':image'),
+      },
+    }],
+    paths: [p],
+    presets: {
+      t_original: {
+        steps: [],
+      },
+    },
+  };
+
+  const mime: Mime =  'image/jpeg';
+
+  describe('Default', () => {
+    let response;
+    beforeAll(async () => {
+      response = new Response();
+      await respond(response, createStream(), mime, config);
+    });
+
+    it('should set `Transfer-Encoding: chunked`', () => {
+      expect(response.set.mock.calls).toContainEqual(
+        expect.arrayContaining(['Transfer-Encoding', 'chunked']),
+      );
+    });
+
+    it('should set `Content-Type` based on the state', () => {
+      expect(response.set.mock.calls).toContainEqual(
+        expect.arrayContaining(['Content-Type', 'image/jpeg']),
+      );
+    });
+  });
+  describe('`disableChunkedEncoding` = true', () => {
+    const chunkedConfig = {
+      ...config,
+      disableChunkedEncoding: true,
+    };
+
+    let response;
+    beforeAll(async () => {
+      response = new Response();
+      await respond(response, createStream(), mime, chunkedConfig);
+    });
+
+    it('should set `Content-Type` based on the state', () => {
+      expect(response.set.mock.calls).toContainEqual(
+        expect.arrayContaining(['Content-Type', 'image/jpeg']),
+      );
+    });
+
+    it('should set `Content-Length` based on the stream', () => {
+      // The stream's size is 100 bytes
+      expect(response.set.mock.calls).toContainEqual(
+        expect.arrayContaining(['Content-Length', '100']),
+      );
+    });
+  });
+});

--- a/src/test/__tests__/storage-set.ts
+++ b/src/test/__tests__/storage-set.ts
@@ -42,10 +42,17 @@ describe('Configured storage', () => {
         stream: jest.fn(),
       },
     ];
-    const mockedStorageResponse = { stream: new PassThrough(), contentType: 'image/jpeg' };
     const storage = {
       exists: jest.fn(() => Promise.resolve(true)),
-      stream: jest.fn(() => Promise.resolve(mockedStorageResponse)),
+      stream: jest.fn(() => {
+        const stream = new PassThrough();
+        stream.push(Buffer.from('some-data'));
+        stream.push(null);
+        return Promise.resolve({
+          stream,
+          contentType: 'image/jpeg',
+        });
+      }),
       upload: jest.fn(),
     };
 
@@ -71,7 +78,7 @@ describe('Configured storage', () => {
       expect(sources[0].stream).not.toHaveBeenCalled();
     });
     it('should set content type as returned from storage', () => {
-      expect(response.set).toBeCalledWith('Content-Type', mockedStorageResponse.contentType);
+      expect(response.set).toBeCalledWith('Content-Type', 'image/jpeg');
     });
     it('should not call storage .upload', () => {
       expect(storage.upload).not.toHaveBeenCalled();

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -18,6 +18,7 @@ const Config = t.Record({
   presets: t.Dictionary(PresetConfig, 'string'),
 }).And(t.Partial({
   storage: Storage,
+  disableChunkedEncoding: t.Boolean,
 })).withConstraint(validateParams);
 
 export type Config = t.Static<typeof Config>;


### PR DESCRIPTION
Add setting that forces SpaceChop to calculate content-length and send entire response, instead of chunked.

Solves #86 