### PR TITLE
Fix issue when analyzing image that does not exist in storage

### DIFF
--- a/src/spacechop.ts
+++ b/src/spacechop.ts
@@ -84,17 +84,18 @@ export const requestHandler = (
   // check if transformation is already done and exists in storage
   if (storage) {
     const fromCache = await fetchFromStorage(storage, params);
-
-    if ('analyze' in req.query) {
-      const { state } = await buildTransformation(fromCache.stream, []);
-      res.json(state);
-      return;
-    }
-    // It exists in cache
-    if (fromCache && fromCache.contentType) {
-      await respond(res, fromCache.stream, fromCache.contentType, config);
-      trace.end();
-      return;
+    if (fromCache !== null) {
+      if ('analyze' in req.query) {
+        const { state } = await buildTransformation(fromCache.stream, []);
+        res.json(state);
+        return;
+      }
+      // It exists in cache
+      if (fromCache.contentType) {
+        await respond(res, fromCache.stream, fromCache.contentType, config);
+        trace.end();
+        return;
+      }
     }
   }
 

--- a/src/test/__tests__/analyze.ts
+++ b/src/test/__tests__/analyze.ts
@@ -85,6 +85,22 @@ describe('Headers', () => {
           expect.objectContaining(expected),
         );
       });
+
+      const missingStorage = {
+        exists: jest.fn(() => Promise.resolve(false)),
+        stream: jest.fn(() => Promise.resolve(null)),
+        upload: jest.fn(),
+      };
+      const missingStorageHandler = requestHandler(config, params, sources, missingStorage);
+      it(`should correctly analyze asset [${asset}] when not existing in storage`, async () => {
+        request.setParams(0, 't_original');
+        request.setParams(1, asset);
+        request.setQuery('analyze');
+        await missingStorageHandler(request, response);
+        expect(response.json).toBeCalledWith(
+          expect.objectContaining(expected),
+        );
+      });
     }
   });
 });


### PR DESCRIPTION
If the image does not exist in storage, and a request with `?analyze` is done the request fails. This PR fixes that issue.