### PR TITLE
Improving png compression.

### DIFF
--- a/src/operations/compress/index.ts
+++ b/src/operations/compress/index.ts
@@ -32,7 +32,8 @@ export const mozjpegOptions = (config: CompressConfig, state: ImageDefinition): 
 export const pngquantOptions = (config: CompressConfig, state: ImageDefinition): string[] => {
   return [
     'pngquant',
-    '--speed 10',
+    `--quality=65-${config.quality}`,
+    '--speed 3',
     '-',
   ];
 };


### PR DESCRIPTION
Google PageSpeed complained on this image:
> If your compress https://images.igdb.com/…/upload/t_cover_small/igdb_tv_d1ibj4.png you can save 426 B (20 % reduction).

https://images.igdb.com/igdb/image/upload/t_cover_small/igdb_tv_d1ibj4.png `2.2 KB`

I found that this image could be improved by even more by tuning the parameters of pngquant, especially adding quality to the arguments and slowing down the speed to 3.

In my test I got it down to `1.2 KB` with the new parameters, saving `1 KB` on an a already small image is fantastic in my regard.