### PR TITLE
fix: pin nodemon to 1.18.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jest-express": "1.7.0",
     "jest-image-snapshot": "^2.4.3",
     "node-exiftool": "^2.3.0",
-    "nodemon": "^1.18.3",
+    "nodemon": "1.18.5",
     "probe-image-size": "~4.0.0",
     "react-router": "^4.3.1",
     "ts-jest": "^23.1.3",


### PR DESCRIPTION
https://github.com/spacechop/spacechop/issues/153