### PR TITLE
Set default magick limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,15 +29,15 @@ ADD scripts/build_production.sh /build_production.sh
 RUN if [ "${env}" = "production" ] ; then sh /build_production.sh ; fi
 
 # Set default image magick policy
-ENV MAGICK_MEMORY_LIMIT=2GiB
-ENV MAGICK_MAP_LIMIT=4GiB
-ENV MAGICK_DISK_LIMIT=16GiB
-ENV MAGICK_AREA_LIMIT=100MP
-ENV MAGICK_HEIGHT_LIMIT=10KP
-ENV MAGICK_WIDTH_LIMIT=10KP
-ENV MAGICK_THREAD_LIMIT=4
-ENV MAGICK_THROTTLE_LIMIT=0
-ENV MAGICK_TIME_LIMIT=3600
+ENV MAGICK_MEMORY_LIMIT=2GiB \
+    MAGICK_MAP_LIMIT=4GiB \
+    MAGICK_DISK_LIMIT=16GiB \
+    MAGICK_AREA_LIMIT=100MP \
+    MAGICK_HEIGHT_LIMIT=10KP \
+    MAGICK_WIDTH_LIMIT=10KP \
+    MAGICK_THREAD_LIMIT=4 \
+    MAGICK_THROTTLE_LIMIT=0 \
+    MAGICK_TIME_LIMIT=3600
 
 # Default empty config to prevent docker volumes
 # to create a directory instead of a file

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,17 @@ ARG env=production
 ADD scripts/build_production.sh /build_production.sh
 RUN if [ "${env}" = "production" ] ; then sh /build_production.sh ; fi
 
+# Set default image magick policy
+ENV MAGICK_MEMORY_LIMIT=2GiB
+ENV MAGICK_MAP_LIMIT=4GiB
+ENV MAGICK_DISK_LIMIT=16GiB
+ENV MAGICK_AREA_LIMIT=100MP
+ENV MAGICK_HEIGHT_LIMIT=10KP
+ENV MAGICK_WIDTH_LIMIT=10KP
+ENV MAGICK_THREAD_LIMIT=4
+ENV MAGICK_THROTTLE_LIMIT=0
+ENV MAGICK_TIME_LIMIT=3600
+
 # Default empty config to prevent docker volumes
 # to create a directory instead of a file
 RUN touch /config.yml


### PR DESCRIPTION
Imagemagick defaults in [policy.xml](https://imagemagick.org/source/policy.xml) are not enabled, I've added so we enable relevant settings through environment as a default.

http://www.imagemagick.org/script/resources.php#environment

related: https://github.com/spacechop/spacechop/issues/172