### PR TITLE
fix mozjpeg build and lock version of dependencies

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -37,6 +37,7 @@ mv /bin/facedetect.cpp /usr/share/dlib/app/facedetect.cpp
 mkdir -p /usr/share/dlib/build/
 # mv shape_predictor_68_face_landmarks.dat /bin/shape_predictor_68_face_landmarks.dat
 cd /usr/share/dlib/build
+git checkout v19.17
 cmake \
   -O0 -j3 \
   -D USE_SSE2_INSTRUCTIONS=ON \
@@ -53,8 +54,11 @@ ln -s /usr/share/dlib-build/facedetect /usr/bin/facedetect
 cd /opt/
 git clone https://github.com/mozilla/mozjpeg.git tmp
 cd tmp
-autoreconf -fiv
-./configure -prefix=/opt/mozjpeg
+git checkout 426de82d # 15 Mar 2019
+mkdir build
+cd build
+CMAKE_INSTALL_PREFIX=/opt/mozjpeg cmake ..
+make
 make install
 rm -rf /opt/tmp
 ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozjpeg
@@ -63,6 +67,7 @@ ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozjpeg
 cd /opt
 git clone https://github.com/pornel/giflossy.git tmp
 cd tmp
+git checkout 1.91
 autoreconf -fiv
 ./configure -prefix=/opt/gifsicle
 make install


### PR DESCRIPTION
I tried to use the `spacechop:latest` docker image but when I try and create the demo application in docker compose, I see the following error in the logs:

```
Listening on port 3000

/src/node_modules/duplex-child-process/index.js:116
      ex = new Error('Command failed: ' + Buffer.concat(stderr).toString('utf8'))
           ^
Error: Command failed: sh: mozjpeg: not found
magick: no decode delegate for this image format `' @ error/constitute.c/ReadImage/556.

    at ChildProcess.onExit (/src/node_modules/duplex-child-process/index.js:116:12)
    at Object.onceWrapper (events.js:277:13)
    at ChildProcess.emit (events.js:189:13)
    at ChildProcess.EventEmitter.emit (domain.js:441:20)
    at maybeClose (internal/child_process.js:970:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
[nodemon] app crashed - waiting for file changes before starting...
```

I tried to build the image myself but it looks like `mozjpeg` fails to build. Fortunately I found [a fork](https://github.com/faisyl/spacechop/commit/e614288e659943b747304a4eb58d6e4603029817) which seems to have the correct build steps. I've substituted the steps from the fork for the existing ones and now `mozjpeg` is built. 

I suspect what may have happened is that while it worked at the time the script was written, something changed in those projects to cause it to break. For that reason, I've locked down the versions to the latest ones (except for `mozjpeg` which has many commits but the last tag is at least 4 years old according to `git tag --sort=committerdate`).