### PR TITLE
Added support for HTTP source using full url.

### DIFF
--- a/src/sources/http/index.ts
+++ b/src/sources/http/index.ts
@@ -30,7 +30,7 @@ export default class HttpSource implements Source {
 
   public exists(params: {}): Promise<boolean> {
     return new Promise((resolve, reject) => {
-      const uri = buildUri(this.config.root, params);
+      const uri = decodeURIComponent(buildUri(this.config.root, params));
       request.head(uri, (err, res) => {
         if (err) {
           console.error('Communicating with HTTP source failed with following error:');
@@ -45,7 +45,7 @@ export default class HttpSource implements Source {
   }
 
   public stream(params: {}): Stream {
-    const uri = buildUri(this.config.root, params);
+    const uri = decodeURIComponent(buildUri(this.config.root, params));
     return request(uri);
   }
 }

--- a/src/sources/http/types.ts
+++ b/src/sources/http/types.ts
@@ -1,11 +1,7 @@
 import * as t from 'runtypes';
 
-const pattern = /^(https?|ftp):\/\/(-\.)?([^\s/?\.#-]+\.?)+(\/[^\s]*)?$/i;
-
 const HttpSourceConfig = t.Record({
-  root: t.String.withConstraint(
-    (n) => (n && n.length > 0 && pattern.test(n)) || 'Requires valid url',
-  ),
+  root: t.String.withConstraint((n) => n && n.length > 0 || 'Requires valid url'),
 });
 
 export type HttpSourceConfig = t.Static<typeof HttpSourceConfig>;


### PR DESCRIPTION
Adding support for configuration like this:

```
paths:
  - /:preset/:image(.*)
sources:
  - http:
      root: :image
```

And request like this:
`http://localhost:8080/t_200/https://i.kinja-img.com/gawker-media/image/upload/s--grxrUy0T--/c_scale,f_auto,fl_progressive,q_80,w_800/eaehfyfz8c8efjoumbnu.jpg`