### PR TITLE
Allow opportunity for hooks when setting up the express app

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,46 @@
+import chokidar from 'chokidar';
+import express from 'express';
+import loadConfig from './config';
+import monitor from './monitor';
+import setupRoutes from './spacechop';
+
+const {
+  PROMETHEUS_METRIC_PATH = '/_health',
+} = process.env;
+
+export function setupApp(app) {
+  // read initial config.
+  let config = loadConfig();
+  app.disable('x-powered-by');
+
+  // create and setup router.
+  let router = express.Router();
+  // Setup routes for the SpaceChop service.
+  setupRoutes(config, router, monitor);
+  // Enable reloading of routes runtime by using a simple router that we switch out.
+  app.use((req, res, next) => {
+    // pass through requests to the router.
+    router(req, res, next);
+  });
+
+  // Re-Initialize routes when new config is loaded.
+  chokidar.watch('/config.yml', {
+    usePolling: true,
+    interval: 1000,
+  }).on('all', async () => {
+    router = express.Router();
+    config = loadConfig();
+    setupRoutes(config, router, monitor);
+  });
+
+  app.get(PROMETHEUS_METRIC_PATH, (_, res) => {
+    res.end(monitor.getMetrics());
+  });
+}
+
+export function createApp() {
+  // create server.
+  const app = express();
+  setupApp(app);
+  return app;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,46 +1,13 @@
-import chokidar from 'chokidar';
-import express from 'express';
-import loadConfig from './config';
-import monitor from './monitor';
-import setupRoutes from './spacechop';
+import {createApp} from './app';
 
 const {
   PORT = 3000,
-  PROMETHEUS_METRIC_PATH = '/_health',
 } = process.env;
 
-// read initial config.
-let config = loadConfig();
-// create server.
-const app = express();
-app.disable('x-powered-by');
+const app = createApp();
 
 // export server to enable testing.
 export let server;
-
-// create and setup router.
-let router = express.Router();
-// Setup routes for the SpaceChop service.
-setupRoutes(config, router, monitor);
-// Enable reloading of routes runtime by using a simple router that we switch out.
-app.use((req, res, next) => {
-  // pass through requests to the router.
-  router(req, res, next);
-});
-
-// Re-Initialize routes when new config is loaded.
-chokidar.watch('/config.yml', {
-  usePolling: true,
-  interval: 1000,
-}).on('all', async () => {
-  router = express.Router();
-  config = loadConfig();
-  setupRoutes(config, router, monitor);
-});
-
-app.get(PROMETHEUS_METRIC_PATH, (_, res) => {
-  res.end(monitor.getMetrics());
-});
 
 // start listening on port.
 server = app.listen(PORT, () => console.info(`Listening on port ${PORT}`));


### PR DESCRIPTION
Our team liked spacechop but we wanted to run it on AWS Lambda. Looking over the code we realized with a slight modification, it would give us the necessary hooks to allow us to run it using [aws-serverless-express](https://github.com/awslabs/aws-serverless-express). 

The change was to create a `setupApp` function in `app.ts` that will take an `express` object and add all the necessary routes. A `createApp` function is added to this file and does the work of setting up the express object and handing it back to the caller. `index.ts` now just does the job of calling `createApp` and starting the server on the specified port.

This allows us to have a separate `lambda.ts` file that looks like something like this:

```
import * as awsServerlessExpress from 'aws-serverless-express';
import express from 'express';
import { addAuthenticationMiddleware } from './authenticate';
import {setupApp} from './src/app';

const app = express();

app.enable('trust proxy');
addAuthenticationMiddleware(app);
setupApp(app);

const server = awsServerlessExpress.createServer(app, null, ['*/*']);

exports.listener = (event: any, context: any) => { 
  return awsServerlessExpress.proxy(server, event, context, 'PROMISE').promise;
};
```

It would be great if this small change can be merged as it has allowed us to extend spacechop by allowing us not only to run on AWS Lambda, but extend it with authentication, error capture and cache headers.