### PR TITLE
fix path so files are saved into directories

### DIFF
--- a/src/lib/compile-path.ts
+++ b/src/lib/compile-path.ts
@@ -9,7 +9,7 @@ export default (pattern, parameters) => {
     throw new Error('Cant compile path. No pattern provided.');
   }
 
-  if (cache[pattern]) { return cache[pattern](parameters); }
+  if (cache[pattern]) { return decodeURIComponent(cache[pattern](parameters)); }
 
   const toPath = pathToRegexp.compile(pattern);
 
@@ -18,5 +18,5 @@ export default (pattern, parameters) => {
     cacheCount++;
   }
 
-  return toPath(parameters);
+  return decodeURIComponent(toPath(parameters));
 };


### PR DESCRIPTION
I've noticed that when files are saved into S3 storage, they're saved with the url path encoded because of `path-to-regexp` over [here](https://github.com/spacechop/spacechop/blob/12380f058146188e7407e64b3f75e72d4bad7f89/src/lib/compile-path.ts#L21) . 

Example:

```
> const pathToRegexp = require('path-to-regexp')
> const path = 'spacechop/:preset/:image';
> const toPath = pathToRegexp.compile(path)
> const params = { preset: 'keyart-png', image: 'movies/media/browser/my_movie.png'}
> toPath(params)
'spacechop/keyart-png/movies%2Fmedia%2Fbrowser%2Fmy_movie.png'
```
What I would prefer is that when these filenames are saved, they keep the pseudo directory structure in the url. Looking over the [options for `path-to-regexp`](https://github.com/pillarjs/path-to-regexp#usage), I can't see anything that let's me turn this encoding off so I've used `decodeURIComponent` here instead. 

Example:

```
> decodeURIComponent(toPath(params))
'spacechop/keyart-png/movies/media/browser/my_movie.png'
```
