### PR TITLE
Add support for minio server

### DIFF
--- a/docs/configuration/sources.md
+++ b/docs/configuration/sources.md
@@ -54,6 +54,22 @@ sources:
       bucket_name: 'my-bucket'
       path: 'originals/:image'
 ```
+
+### Example ([minio](https://min.io/))
+```yaml
+sources:
+  - s3:
+      access_key_id: 'xxxx'
+      secret_access_key: 'yyy'
+      region: 'us-east-1'
+      bucket_name: 'my-bucket'
+      path: '/originals/:image'
+      endpoint: "http://localhost:9000"
+      sslDisabled: true
+      signatureVersion: "v4"
+      s3ForcePathStyle: true
+```
+
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
@@ -124,6 +140,33 @@ sources:
         <p></p>
         <p><b>Type: </b>string</p>
         <p><b>Default: </b>derived from bucket_name and region, as per AWS standard.</p>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">sslDisabled</td>
+      <td style="text-align:left">
+        <p>Disable SSL validation (useful when using a local S3 compatible server, minio)</p>
+        <p></p>
+        <p><b>Type: </b>boolean</p>
+        <p><b>Default: </b>false</p>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">signatureVersion</td>
+      <td style="text-align:left">
+        <p>S3 Signature Version (useful when using a local S3 compatible server, like minio)</p>
+        <p></p>
+        <p><b>Type: </b>string</p>
+        <p><b>Default: </b>defaults to AWS SDK internal default value for this setting</p>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">s3ForcePathStyle</td>
+      <td style="text-align:left">
+        <p>S3 force path style (useful when using a local S3 compatible server, like minio)</p>
+        <p></p>
+        <p><b>Type: </b>string</p>
+        <p><b>Default: </b>defaults to AWS SDK internal default value for this setting</p>
       </td>
     </tr>
   </tbody>

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,6 @@
 {
   "watch": ["."],
   "ext": "ts",
-  "ignore": ["app/**/*.spec.ts"],
-  "exec": "npx ts-node app/index.ts"
+  "ignore": ["src/**/*.spec.ts"],
+  "exec": "npx ts-node src/index.ts"
 }

--- a/src/lib/extractPathParams.ts
+++ b/src/lib/extractPathParams.ts
@@ -1,8 +1,18 @@
 import pathToRegexp from 'path-to-regexp';
+import { parse } from 'url';
 
 const cache = {};
 const cacheLimit = 10000;
 let cacheCount = 0;
+
+function getApplicablePath(pattern) {
+  const parsed = parse(pattern);
+  if (parsed.host) {
+    return parsed.pathname;
+  }
+
+  return pattern;
+}
 
 export default (pattern) => {
   if (!pattern) {
@@ -12,7 +22,8 @@ export default (pattern) => {
   if (cache[pattern]) { return cache[pattern]; }
 
   const keys = [];
-  pathToRegexp(pattern, keys);
+
+  pathToRegexp(getApplicablePath(pattern), keys);
 
   if (cacheCount < cacheLimit) {
     cache[pattern] = keys;

--- a/src/sources/s3/types.ts
+++ b/src/sources/s3/types.ts
@@ -1,15 +1,21 @@
 import * as t from 'runtypes';
 
-const S3SourceConfig = t.Record({
-    access_key_id: t.String.withConstraint((n) => n && n.length > 0),
-    secret_access_key: t.String.withConstraint((n) => n && n.length > 0),
-    region: t.String.withConstraint((n) => n && n.length > 0),
-    bucket_name: t.String.withConstraint((n) => n && n.length > 0),
-    path: t.String.withConstraint((n) => n && n.length > 0),
-}).And(t.Partial({
-  endpoint: t.String,
-}));
-
+const S3SourceConfig = t
+  .Record({
+    access_key_id: t.String.withConstraint(n => n && n.length > 0),
+    secret_access_key: t.String.withConstraint(n => n && n.length > 0),
+    region: t.String.withConstraint(n => n && n.length > 0),
+    bucket_name: t.String.withConstraint(n => n && n.length > 0),
+    path: t.String.withConstraint(n => n && n.length > 0)
+  })
+  .And(
+    t.Partial({
+      endpoint: t.String,
+      sslDisabled: t.Boolean,
+      signatureVersion: t.String,
+      s3ForcePathStyle: t.Boolean
+    })
+  );
 
 export type S3SourceConfig = t.Static<typeof S3SourceConfig>;
 export default S3SourceConfig;

--- a/src/types/__tests__/__snapshots__/Sources.ts.snap
+++ b/src/types/__tests__/__snapshots__/Sources.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`validate Sources invalid should require sources 1`] = `"Expected array, but was object"`;
 
-exports[`validate Sources invalid should require valid source 1`] = `"Expected { http: { root: string; }; } | { s3: { access_key_id: string; secret_access_key: string; region: string; bucket_name: string; path: string; } & { endpoint?: string; }; } | { volume: { root: string; }; }, but was object"`;
+exports[`validate Sources invalid should require valid source 1`] = `"Expected { http: { root: string; }; } | { s3: { access_key_id: string; secret_access_key: string; region: string; bucket_name: string; path: string; } & { endpoint?: string; sslDisabled?: boolean; signatureVersion?: string; s3ForcePathStyle?: boolean; }; } | { volume: { root: string; }; }, but was object"`;
 
 exports[`validate Sources invalid should require valid sources array 1`] = `"Expected array, but was object"`;
 
-exports[`validate Sources invalid should throw on any other type of source 1`] = `"Expected { http: { root: string; }; } | { s3: { access_key_id: string; secret_access_key: string; region: string; bucket_name: string; path: string; } & { endpoint?: string; }; } | { volume: { root: string; }; }, but was object"`;
+exports[`validate Sources invalid should throw on any other type of source 1`] = `"Expected { http: { root: string; }; } | { s3: { access_key_id: string; secret_access_key: string; region: string; bucket_name: string; path: string; } & { endpoint?: string; sslDisabled?: boolean; signatureVersion?: string; s3ForcePathStyle?: boolean; }; } | { volume: { root: string; }; }, but was object"`;


### PR DESCRIPTION
This MR adds support for the S3 compatible [minio](https://min.io) server:

Changes:
- Changed param extraction to allow for URLs with port number
- Introduced new source configuration parameters (by exposing AWS SDK internal params), needed for compatibility of the AWS SDK with the minio server
- Added example source configuration for minio and parameter documentation

